### PR TITLE
feat: auto-detect country and language on user sign-in

### DIFF
--- a/src/app/(app)/api/geo/route.ts
+++ b/src/app/(app)/api/geo/route.ts
@@ -3,9 +3,13 @@ import { geolocation } from "@vercel/functions";
 
 export const dynamic = "force-dynamic";
 
-export function GET(_req: Request) {
+export function GET(req: Request) {
   try {
-    const geo = geolocation(_req); // { country, region, city, latitude, longitude }
+    const geo = geolocation(req);
+    
+    // NEW: Extract language from Accept-Language header (robust parsing)
+    const acceptLanguage = req.headers.get('accept-language') ?? 'en';
+    const language = acceptLanguage.split(',')[0]?.split('-')[0]?.toLowerCase() || 'en';
     
     // Dev fallback for localhost testing (ChatGPT's suggestion)
     if (!geo?.country && process.env.NODE_ENV !== "production") {
@@ -18,17 +22,29 @@ export function GET(_req: Request) {
       };
       console.log("Geo route: Using dev fallback for localhost");
       return NextResponse.json(
-        { geo: dev, source: "dev-mock" },
+        { 
+          geo: dev, 
+          language: "de", // Add language to dev fallback
+          source: "dev-mock" 
+        },
         { headers: { "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0" } }
       );
     }
     
     return NextResponse.json(
-      { geo, source: "vercel" },
+      { 
+        geo, 
+        language, // NEW: Include detected language
+        source: "vercel" 
+      },
       { headers: { "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0" } }
     );
   } catch (err) {
     console.error("Geo route error:", err);
-    return NextResponse.json({ geo: null, error: "Failed to fetch location" }, { status: 500 });
+    return NextResponse.json({ 
+      geo: null, 
+      language: "en", // Include language in error response
+      error: "Failed to fetch location" 
+    }, { status: 500 });
   }
 }

--- a/src/modules/profile/location-utils.ts
+++ b/src/modules/profile/location-utils.ts
@@ -299,6 +299,16 @@ export function getLocaleAndCurrency() {
   return { locale: "en-US", currency: "EUR" };
 }
 
+// Add this new helper function
+export function normalizeToSupported(code?: string): "en" | "es" | "fr" | "de" | "it" | "pt" {
+  const fallback = getInitialLanguage();
+  if (!code) return fallback;
+  
+  const short = code.split(',')[0]?.split('-')[0] ?? code;
+  const supportedCodes = ["en", "es", "fr", "de", "it", "pt"] as const;
+  return supportedCodes.includes(short as "en" | "es" | "fr" | "de" | "it" | "pt") ? short as "en" | "es" | "fr" | "de" | "it" | "pt" : fallback;
+}
+
 // New helper functions for consistent location display formatting
 export function countryNameFromCode(code?: string, locale = "en"): string {
   if (!code) return "";


### PR DESCRIPTION
- Add language detection from Accept-Language header in /api/geo
- Enhance GeoBootstrap to send country/language with coordinates
- Implement ironclad protection against coordinate overwrites after onboarding
- Add normalizeToSupported utility for language code normalization
- Remove localStorage gate to allow updates for non-onboarded users
- Only update top-level fields when onboardingCompleted === false
- Reuse existing location-utils for consistent country name formatting