### PR TITLE
fix(auth,tenants): stabilize distance calc + bridge cookie; harden JW…

### DIFF
--- a/src/app/(app)/api/auth/bridge/route.ts
+++ b/src/app/(app)/api/auth/bridge/route.ts
@@ -3,18 +3,11 @@ import { NextResponse } from "next/server";
 import { cookies as nextCookies } from "next/headers";
 import { auth } from "@clerk/nextjs/server";
 import { verifyToken } from "@clerk/backend";
-import { BRIDGE_COOKIE } from "@/constants";
+import { BRIDGE_COOKIE, BRIDGE_COOKIE_OPTS } from "@/constants";
 import { signBridgeToken, verifyBridgeToken } from "@/lib/app-auth";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-const isProd = process.env.NODE_ENV === "production";
-
-const ROOT = process.env.NEXT_PUBLIC_ROOT_DOMAIN || "";
-const COOKIE_DOMAIN = isProd
-  ? process.env.CLERK_COOKIE_DOMAIN || (ROOT ? `.${ROOT}` : undefined)
-  : undefined;
 
 const TTL_SECONDS = 90; // Bridge cookie lifetime
 
@@ -121,17 +114,12 @@ export async function GET(req: Request) {
       TTL_SECONDS
     );
     res.cookies.set(BRIDGE_COOKIE, token, {
-      httpOnly: true,
-      secure: isProd,
-      sameSite: "lax",
-      domain: COOKIE_DOMAIN,
-      path: "/",
+      ...BRIDGE_COOKIE_OPTS,
       maxAge: TTL_SECONDS,
     });
   } else if (existing) {
     res.cookies.set(BRIDGE_COOKIE, "", {
-      domain: COOKIE_DOMAIN,
-      path: "/",
+      ...BRIDGE_COOKIE_OPTS,
       maxAge: 0,
     });
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,3 +20,21 @@ export const FAIL_HIGHLIGHT_MS = 2000;
 export const BOOKING_CH = "booking-updates" as const;
 
 export const BRIDGE_COOKIE = "inf_br" as const;
+
+// Bridge cookie options with dev environment gating
+export const BRIDGE_COOKIE_OPTS =
+  process.env.NODE_ENV === "production"
+    ? ({
+        httpOnly: true,
+        secure: true,
+        sameSite: "none" as const,
+        domain: `.${process.env.NEXT_PUBLIC_ROOT_DOMAIN}`,
+        path: "/",
+      })
+    : ({
+        httpOnly: true,
+        secure: false,
+        sameSite: "lax" as const,
+        // no domain on localhost
+        path: "/",
+      });

--- a/src/modules/bookings/ui/CalendarNav.tsx
+++ b/src/modules/bookings/ui/CalendarNav.tsx
@@ -22,7 +22,6 @@ type Props = {
 };
 
 export default function CalendarNav(props: Props) {
-  // eslint-disable-next-line -- Next.js "serializable props" false positive for client→client usage
   const {
     anchor,
     onAnchorChange,

--- a/src/modules/tenants/utils/normalize-for-card.ts
+++ b/src/modules/tenants/utils/normalize-for-card.ts
@@ -2,6 +2,8 @@ import type { TenantWithRelations } from "@/modules/tenants/types";
 import type { Category, Tenant, Media, User } from "@/payload-types";
 import { calculateDistance } from "@/modules/tenants/distance-utils";
 
+const round1 = (n: number) => Math.max(0, Math.round(n * 10) / 10);
+
 type ViewerCoords = { lat: number; lng: number } | null | undefined;
 
 // Type for the raw data returned by getOne procedure
@@ -63,12 +65,13 @@ export function normalizeForCard(raw: RawTenantData, viewerCoords?: ViewerCoords
     user?.coordinates?.lat != null &&
     user?.coordinates?.lng != null
   ) {
-    distance = calculateDistance(
+    const rawDistance = calculateDistance(
       viewerCoords.lat,
       viewerCoords.lng,
       user.coordinates.lat,
       user.coordinates.lng
     );
+    distance = round1(rawDistance);
   }
 
   return {


### PR DESCRIPTION
…T; tidy caching

- tenants(list): add strict cache controls to prevent “last-user distance” flash
  - useSuspenseInfiniteQuery now sets: staleTime=0, gcTime=0, refetchOnMount="always", refetchOnReconnect="always", refetchOnWindowFocus=false, placeholderData
- tenants(normalize-for-card): clamp/round distance to 1dp (no negative/-0.0)
- auth(bridge): centralize cookie settings with env-aware BRIDGE_COOKIE_OPTS
  - dev: httpOnly, sameSite=lax, secure=false, no domain
  - prod: httpOnly, sameSite=none, secure=true, domain= .${NEXT_PUBLIC_ROOT_DOMAIN}
  - update API route to use BRIDGE_COOKIE_OPTS for set/clear
- auth(app-auth): harden JWT
  - require APP_BRIDGE_SECRET length >= 32
  - add issuer + audience + iat/nbf/exp + clockTolerance
  - seconds-based time handling
- refactor: rename constants.tsx → constants.ts; remove unused COOKIE_DOMAIN code
- ui(CalendarNav): drop unused eslint-disable Notes:
- Ensure APP_BRIDGE_SECRET is set in .env.local (and Vercel for all envs).
- This change removes reliance on CLERK_COOKIE_DOMAIN for the bridge cookie.