### PR TITLE
feat(checkout): add “Book slots” cart flow + drawer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,8 @@
         "svix": "^1.69.0",
         "tailwind-merge": "^3.3.1",
         "vaul": "^1.1.2",
-        "zod": "^3.25.75"
+        "zod": "^3.25.75",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -15796,6 +15797,34 @@
       "integrity": "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "svix": "^1.69.0",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
-    "zod": "^3.25.75"
+    "zod": "^3.25.75",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/modules/checkout/cart-utils.ts
+++ b/src/modules/checkout/cart-utils.ts
@@ -1,0 +1,29 @@
+// src/modules/checkout/utils/cart-utils.ts
+
+export type RatePick = {
+  hourlyRate?: number | string | null;
+  hourly_rate?: number | string | null;
+  ratePerHour?: number | string | null;
+  pricePerHour?: number | string | null;
+};
+
+/**
+ * Safely read a tenant's hourly rate and return value in CENTS.
+ * Accepts number or numeric string. Falls back to 0 when missing/invalid.
+ */
+export function getHourlyRateCents(t: unknown): number {
+  if (!t || typeof t !== "object") return 0;
+  const r = t as RatePick;
+
+  const raw =
+    r.hourlyRate ?? r.hourly_rate ?? r.ratePerHour ?? r.pricePerHour ?? 0;
+
+  const n =
+    typeof raw === "string"
+      ? parseFloat(raw)
+      : typeof raw === "number"
+        ? raw
+        : 0;
+
+  return Number.isFinite(n) ? Math.round(n * 100) : 0;
+}

--- a/src/modules/checkout/hooks/use-cart.ts
+++ b/src/modules/checkout/hooks/use-cart.ts
@@ -1,0 +1,99 @@
+"use client";
+
+import { useMemo, useCallback } from "react";
+import { useCartStore, type CartItem } from "../store/use-cart-store";
+
+const EMPTY: CartItem[] = []; // stable, top-level constant
+
+/** Tenant-scoped cart helpers (tutorial-style ergonomics). */
+export function useCart(tenantId: string) {
+  // Select slices individually (no object selector → no new refs)
+  const tenant = useCartStore((s) => s.tenant);
+  const items = useCartStore((s) => s.items);
+  const add = useCartStore((s) => s.add);
+  const addMany = useCartStore((s) => s.addMany);
+  const remove = useCartStore((s) => s.remove);
+  const toggle = useCartStore((s) => s.toggle);
+  const clear = useCartStore((s) => s.clear);
+  const setOpen = useCartStore((s) => s.setOpen);
+
+  const hasOtherTenant = tenant !== null && tenant !== tenantId;
+
+  // ---- tenant-bound actions ----
+  const addSlot = useCallback(
+    (item: CartItem) => add(tenantId, item),
+    [add, tenantId]
+  );
+  const addSelected = useCallback(
+    (slotItems: CartItem[]) => addMany(tenantId, slotItems),
+    [addMany, tenantId]
+  );
+  const toggleSlot = useCallback(
+    (item: CartItem) => toggle(tenantId, item),
+    [toggle, tenantId]
+  );
+  const removeSlot = useCallback((slotId: string) => remove(slotId), [remove]);
+  const openCart = useCallback(() => setOpen(true), [setOpen]);
+  const closeCart = useCallback(() => setOpen(false), [setOpen]);
+
+  // ---- derived for this tenant ----
+  const tenantItems = useMemo(
+    () => (hasOtherTenant ? EMPTY : items),
+    [hasOtherTenant, items]
+  );
+
+  const totalItems = tenantItems.length;
+
+  // avoid reduce typing noise; tiny loop is crystal clear
+  const totalPriceCents = useMemo(() => {
+    let sum = 0;
+    for (const it of tenantItems) sum += it.priceCents;
+    return sum;
+  }, [tenantItems]);
+
+  const inCart = useCallback(
+    (slotId: string) => tenantItems.some((x: CartItem) => x.id === slotId),
+    [tenantItems]
+  );
+
+  const clearTenantCart = useCallback(() => {
+    if (items.length) clear();
+  }, [clear, items.length]);
+
+  return {
+    // data
+    items: tenantItems,
+    totalItems,
+    totalPriceCents,
+    hasOtherTenant,
+    // actions
+    addSlot,
+    addSelected,
+    toggleSlot,
+    removeSlot,
+    clearTenantCart,
+    openCart,
+    closeCart,
+    inCart,
+  };
+}
+
+/**
+ * useCart(tenantId)
+ * ------------------
+ * Tenant-scoped wrapper around the global cart store.
+ *
+ * What it does:
+ * - Selects only the fields/actions needed from useCartStore (keeps re-renders low).
+ * - Binds actions to the provided tenantId: addSlot, addSelected, toggleSlot, removeSlot.
+ * - Computes tenant-specific derived data: `items`, `totalItems`, `totalPriceCents`.
+ * - Enforces one-tenant-per-order: if the cart belongs to another tenant,
+ *   this hook exposes an empty list (`hasOtherTenant` becomes true).
+ * - Exposes UI helpers to control the checkout drawer: `openCart` / `closeCart`.
+ * - Keeps cart state ephemeral (no localStorage) because time slots can expire
+ *   and the app spans multiple origins (subdomains/previews), which would make
+ *   persisted carts stale or appear "lost".
+ *
+ * Typical usage:
+ *   const { items, totalItems, inCart, addSlot, addSelected, openCart } = useCart(tenant.slug);
+ */

--- a/src/modules/checkout/store/use-cart-store.ts
+++ b/src/modules/checkout/store/use-cart-store.ts
@@ -1,0 +1,116 @@
+"use client";
+
+import { create } from "zustand";
+
+export type CartItem = {
+  id: string; // slot id
+  startIso: string;
+  endIso: string;
+  priceCents: number; // rate * duration (in cents)
+  serviceId?: string | null;
+};
+
+type CartState = {
+  tenant: string | null; // one-tenant-per-order guard
+  items: CartItem[];
+  open: boolean; // controls the checkout sheet/drawer
+
+  // derived
+  count: () => number;
+  totalCents: () => number;
+
+  // actions
+  setOpen: (v: boolean) => void;
+  clear: () => void;
+  add: (tenant: string, item: CartItem) => boolean; // false => cart has other tenant
+  addMany: (tenant: string, items: CartItem[]) => boolean;
+  remove: (slotId: string) => void;
+  toggle: (tenant: string, item: CartItem) => boolean; // add if absent, remove if present
+  setService: (slotId: string, serviceId: string | null) => void;
+};
+
+export const useCartStore = create<CartState>((set, get) => ({
+  tenant: null,
+  items: [],
+  open: false,
+
+  // derived
+  count: () => get().items.length,
+  totalCents: () => get().items.reduce((s, i) => s + i.priceCents, 0),
+
+  // ui
+  setOpen: (v) => set({ open: v }),
+  clear: () => set({ items: [], tenant: null }),
+
+  // core
+  add: (tenant, item) => {
+    const s = get();
+    if (s.items.length && s.tenant && s.tenant !== tenant) return false;
+    set((prev) => {
+      const exists = prev.items.some((x) => x.id === item.id);
+      return {
+        tenant: prev.tenant ?? tenant,
+        items: exists ? prev.items : [...prev.items, item],
+      };
+    });
+    return true;
+  },
+
+  addMany: (tenant, items) => {
+    const s = get();
+    if (s.items.length && s.tenant && s.tenant !== tenant) return false;
+    set((prev) => {
+      const seen = new Set(prev.items.map((x) => x.id));
+      const merged = items.filter((x) => !seen.has(x.id));
+      return {
+        tenant: prev.tenant ?? tenant,
+        items: [...prev.items, ...merged],
+      };
+    });
+    return true;
+  },
+
+  remove: (slotId) =>
+    set((prev) => ({ items: prev.items.filter((x) => x.id !== slotId) })),
+
+  toggle: (tenant, item) => {
+    const s = get();
+    if (s.items.length && s.tenant && s.tenant !== tenant) return false;
+    const exists = s.items.some((x) => x.id === item.id);
+    set((prev) => ({
+      tenant: prev.tenant ?? tenant,
+      items: exists
+        ? prev.items.filter((x) => x.id !== item.id)
+        : [...prev.items, item],
+    }));
+    return true;
+  },
+
+  setService: (slotId, serviceId) =>
+    set((prev) => ({
+      items: prev.items.map((x) => (x.id === slotId ? { ...x, serviceId } : x)),
+    })),
+}));
+
+// Optional helper to build a CartItem from a calendar slot
+export function slotToCartItem(
+  slot: { id: string; start: string; end: string },
+  pricePerHourCents: number
+): CartItem {
+  const ms = +new Date(slot.end) - +new Date(slot.start);
+  const hours = Math.max(1, Math.round(ms / 3_600_000));
+  return {
+    id: slot.id,
+    startIso: slot.start,
+    endIso: slot.end,
+    priceCents: pricePerHourCents * hours,
+  };
+}
+
+// NOTE: We intentionally do NOT persist this cart to localStorage.
+// 1) Booking slots can disappear or be taken by others. Persisting would
+//    resurrect stale items after reload and cause failed checkouts.
+// 2) The app runs on multiple origins (tenant subdomains, preview URLs).
+//    localStorage is per-origin, so carts would seem to “vanish” between them.
+// 3) Avoids SSR/hydration issues from touching localStorage on first paint.
+// If we decide to persist later, prefer sessionStorage + server re-validation.

--- a/src/modules/checkout/ui/book-slots-button.tsx
+++ b/src/modules/checkout/ui/book-slots-button.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+// keep your existing hook path
+import { useCart } from "@/modules/checkout/hooks/use-cart";
+import {
+  slotToCartItem,
+  type CartItem,
+} from "@/modules/checkout/store/use-cart-store";
+import { useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+type Props = {
+  tenantSlug: string;
+  selectedIds: string[];
+  /** e.g. 15 €/h -> 1500 */
+  pricePerHourCents: number;
+  onAdded?: () => void;
+};
+
+// Tiny helpers to make TS happy and avoid `any`
+type BookingLite = { id: string; start: string; end: string };
+type MaybeBookings = BookingLite[] | { items?: BookingLite[] } | undefined;
+
+function toBookingsArray(data: MaybeBookings): BookingLite[] {
+  if (!data) return [];
+  if (Array.isArray(data)) return data.filter(isBookingLite);
+  if (Array.isArray(data.items)) return data.items.filter(isBookingLite);
+  return [];
+}
+function isBookingLite(x: unknown): x is BookingLite {
+  return (
+    !!x && typeof x === "object" && "id" in x && "start" in x && "end" in x
+  );
+}
+
+export function BookSlotsButton({
+  tenantSlug,
+  selectedIds,
+  pricePerHourCents,
+  onAdded,
+}: Props) {
+  const { addSelected, openCart } = useCart(tenantSlug);
+  const qc = useQueryClient();
+
+  // Build an index of id -> {start,end} from ALL bookings queries in cache
+  const slotIndex = useMemo(() => {
+    const index = new Map<string, { start: string; end: string }>();
+    const snaps = qc.getQueriesData<MaybeBookings>({
+      predicate: (q) => {
+        const s = JSON.stringify(q.queryKey ?? []);
+        return (
+          s.includes('"bookings"') &&
+          (s.includes('"listPublicSlots"') || s.includes('"listMine"'))
+        );
+      },
+    });
+
+    for (const [, data] of snaps) {
+      for (const b of toBookingsArray(data)) {
+        index.set(String(b.id), { start: String(b.start), end: String(b.end) });
+      }
+    }
+    return index;
+  }, [qc]);
+
+  const onClick = () => {
+    if (!selectedIds.length) return;
+
+    const items: CartItem[] = [];
+    for (const id of selectedIds) {
+      const s = slotIndex.get(id);
+      if (!s) continue; // not in cache → skip quietly for now
+      items.push(
+        slotToCartItem({ id, start: s.start, end: s.end }, pricePerHourCents)
+      );
+    }
+
+    const ok = addSelected(items);
+    if (ok) {
+      onAdded?.(); // clear selection if you passed it
+      openCart();
+    }
+  };
+
+  return (
+    <Button
+      disabled={!selectedIds.length}
+      onClick={onClick}
+      className="px-4 py-2"
+    >
+      {selectedIds.length ? `Book slots (${selectedIds.length})` : "Book slots"}
+    </Button>
+  );
+}

--- a/src/modules/checkout/ui/cart-button.tsx
+++ b/src/modules/checkout/ui/cart-button.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useCart } from "@/modules/checkout/hooks/use-cart";
+
+export function CartButton({ tenantSlug }: { tenantSlug: string }) {
+  const { totalItems, openCart } = useCart(tenantSlug);
+
+  return (
+    <Button onClick={openCart} variant="secondary" className="min-w-[150px]">
+      {totalItems ? `Open cart (${totalItems})` : "Open cart"}
+    </Button>
+  );
+}
+
+// For now you don’t have start/end in selected—only IDs—so keep the working Cart button above. When you expose the slot details from the calendar or via a small query, we’ll swap the “Book selected” button for this “Add selected to cart” button.
+
+// import { Button } from "@/components/ui/button";
+// import { useCart } from "@/modules/checkout/store/hooks/use-cart";
+// import {
+//   slotToCartItem,
+//   CartItem,
+// } from "@/modules/checkout/store/use-cart-store";
+
+// type MinimalSlot = { id: string; start: string; end: string };
+
+// export function AddSelectedToCartButton({
+//   tenantSlug,
+//   selectedSlots, // [{ id, start, end }]
+//   pricePerHourCents, // e.g. Math.round(hourlyRate * 100)
+// }: {
+//   tenantSlug: string;
+//   selectedSlots: MinimalSlot[];
+//   pricePerHourCents: number;
+// }) {
+//   const { addSelected, openCart } = useCart(tenantSlug);
+
+//   const onClick = () => {
+//     const items: CartItem[] = selectedSlots.map((s) =>
+//       slotToCartItem(
+//         { id: s.id, start: s.start, end: s.end },
+//         pricePerHourCents
+//       )
+//     );
+//     const ok = addSelected(items);
+//     if (ok) openCart();
+//   };
+
+//   return (
+//     <Button disabled={!selectedSlots.length} onClick={onClick}>
+//       {selectedSlots.length
+//         ? `Add selected (${selectedSlots.length})`
+//         : "Add selected"}
+//     </Button>
+//   );
+// }

--- a/src/modules/checkout/ui/cart-drawer.tsx
+++ b/src/modules/checkout/ui/cart-drawer.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetFooter,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { useCartStore } from "@/modules/checkout/store/use-cart-store";
+
+const EUR = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "EUR",
+});
+
+export function CartDrawer() {
+  const open = useCartStore((s) => s.open);
+  const setOpen = useCartStore((s) => s.setOpen);
+  const items = useCartStore((s) => s.items);
+  const clear = useCartStore((s) => s.clear);
+
+  const totalCents = items.reduce((sum, it) => sum + (it.priceCents ?? 0), 0);
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetContent side="right" className="w-[420px] sm:w-[520px]">
+        <SheetHeader>
+          <SheetTitle>Booking cart</SheetTitle>
+        </SheetHeader>
+
+        {items.length === 0 ? (
+          <p className="text-sm text-muted-foreground mt-4">Cart is empty.</p>
+        ) : (
+          <ul className="mt-4 space-y-3">
+            {items.map((it) => {
+              const start = new Date(it.startIso);
+              const end = new Date(it.endIso);
+              const when =
+                isFinite(start.getTime()) && isFinite(end.getTime())
+                  ? `${start.toLocaleDateString()} • ${start.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}–${end.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`
+                  : "—";
+              return (
+                <li
+                  key={it.id}
+                  className="border rounded-md p-3 text-sm flex items-center justify-between"
+                >
+                  <div className="mr-3">
+                    <div className="font-medium">{when}</div>
+                    <div className="text-muted-foreground">
+                      Slot ID: {it.id}
+                    </div>
+                  </div>
+                  <div className="font-semibold">
+                    {EUR.format((it.priceCents ?? 0) / 100)}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <SheetFooter className="mt-4">
+          <div className="w-full">
+            <div className="flex items-center justify-between text-base mb-3">
+              <span>Total</span>
+              <span className="font-semibold">
+                {EUR.format(totalCents / 100)}
+              </span>
+            </div>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => clear()}>
+                Clear
+              </Button>
+              <Button className="flex-1" onClick={() => setOpen(false)}>
+                Checkout (soon)
+              </Button>
+            </div>
+          </div>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/modules/tenants/ui/components/tenant_page/tenant-content.tsx
+++ b/src/modules/tenants/ui/components/tenant_page/tenant-content.tsx
@@ -22,6 +22,11 @@ import LoadingPage from "@/components/shared/loading";
 import type { Category } from "@/payload-types";
 import { useUser } from "@clerk/nextjs";
 import dynamic from "next/dynamic";
+// import { CartButton } from "@/modules/checkout/ui/cart-button";
+// add:
+import { BookSlotsButton } from "@/modules/checkout/ui/book-slots-button";
+import { CartDrawer } from "@/modules/checkout/ui/cart-drawer";
+import { getHourlyRateCents } from "@/modules/checkout/cart-utils";
 
 // near top (module scope is fine)
 const BOOKING_CH = "booking-updates" as const;
@@ -379,6 +384,13 @@ export default function TenantContent({ slug }: { slug: string }) {
                 </Button>
               )}
             </div>
+            <BookSlotsButton
+              tenantSlug={slug}
+              selectedIds={selected}
+              pricePerHourCents={getHourlyRateCents(cardTenant)}
+              onAdded={() => setSelected([])} // clear calendar selection
+            />
+            <CartDrawer />
 
             {/* Sticky mobile CTA (mobile only) */}
             <div
@@ -394,6 +406,12 @@ export default function TenantContent({ slug }: { slug: string }) {
                   ? `Book ${selected.length} slot${selected.length > 1 ? "s" : ""}`
                   : "Select slots to book"}
               </Button>
+              <BookSlotsButton
+                tenantSlug={slug}
+                selectedIds={selected}
+                pricePerHourCents={getHourlyRateCents(cardTenant)}
+                onAdded={() => setSelected([])} // clear calendar selection
+              />
             </div>
           </section>
 


### PR DESCRIPTION
- create Zustand cart store (ephemeral, no persist) with one-tenant guard
- add tenant-scoped hook `useCart(tenantId)` for add/remove/toggle/open/clear
- implement `BookSlotsButton`:
  - reads selected slot IDs
  - pulls {start,end} from React Query bookings cache
  - maps to CartItem via `slotToCartItem(pricePerHourCents)`
  - adds items and opens drawer
- add `CartDrawer` (shadcn Sheet) showing each slot (date/time) with price and total; clear action; checkout placeholder
- add `getHourlyRateCents` util to normalize rate → cents
- integrate in tenant page: render “Book slots (n)” under calendar and mount `CartDrawer`
- keep existing “Book selected” (server booking) for now; `CartButton` acts as drawer trigger

refs: multi-serv booking → checkout groundwork