### PR TITLE
feat(stripe): switch Checkout to Direct Charges

### DIFF
--- a/src/modules/auth/server/procedures.ts
+++ b/src/modules/auth/server/procedures.ts
@@ -279,7 +279,7 @@ export const authRouter = createTRPCRouter({
         ({ id: accountId } = await stripe.accounts.create(
           {
             type: "express",
-            capabilities: { transfers: { requested: true } }, // destination charges
+            capabilities: { card_payments: { requested: true } }, // direct charges
             metadata: {
               platformUserId,
               tenantName: input.name ?? "",

--- a/src/modules/checkout/server/procedures.ts
+++ b/src/modules/checkout/server/procedures.ts
@@ -246,7 +246,6 @@ export const checkoutRouter = createTRPCRouter({
             payment_intent_data: {
               application_fee_amount: feeCents,
               // transfer_data: { destination: tenant.stripeAccountId as string },  // this was for destination charges - wrong we use direct charges to the tenant
-              on_behalf_of: tenant.stripeAccountId as string, // optional but recommended
               // ensure PI also carries metadata (fallback webhook path)
               metadata,
             },


### PR DESCRIPTION
- Remove transfer_data.destination; add on_behalf_of
- Create Checkout Session on connected account via { stripeAccount }
- Webhook: use event.account when retrieving Stripe objects
- Keep platform fee via application_fee_amount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enable payments on connected accounts with direct charges and on-behalf-of support; request card_payments capability for Express accounts.
  - Support optional invoice creation from Checkout sessions.

- **Bug Fixes**
  - Automatically generate and store receipt links for both platform and connected-account payments.
  - Improve reliability of receipt URL enrichment with non-blocking error handling.

- **Refactor**
  - Streamline Checkout session creation and option handling for consistent behavior across account types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->